### PR TITLE
Refine mobile filter layout for dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Plus, Filter, Search, ChevronDown, ChevronUp, List, LayoutGrid } from 'lucide-react';
+import { Plus, Filter, Search, List, LayoutGrid } from 'lucide-react';
 
 import Navbar from '../components/Navbar';
 import TodoItem from '../components/TodoItem';
@@ -42,7 +42,6 @@ const Dashboard: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterStatus, setFilterStatus] = useState<'all' | 'active' | 'completed'>('all');
   const [filterPriority, setFilterPriority] = useState<'all' | 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'>('all');
-  const [isFiltersExpanded, setIsFiltersExpanded] = useState(false);
   const [isCompactView, setIsCompactView] = useState(false);
   const [darkMode, setDarkMode] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -230,12 +229,15 @@ const Dashboard: React.FC = () => {
 
             {/* Search and Filters */}
             <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-${isCompactView ? "2" : "6"}`}>
-              {/* Search bar with filter toggle (mobile) */}
-              <div className="p-4 border-b border-gray-200 dark:border-gray-700 md:border-b-0">
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
+              <div className="p-4 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                <div className="flex-1">
+                  <label htmlFor="todo-search" className="sr-only">
+                    Search todos
+                  </label>
+                  <div className="relative">
                     <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
                     <input
+                      id="todo-search"
                       type="text"
                       placeholder="Search todos..."
                       value={searchTerm}
@@ -243,90 +245,43 @@ const Dashboard: React.FC = () => {
                       className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors"
                     />
                   </div>
-                  {/* Filter toggle button (mobile only) */}
-                  <button
-                    onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
-                    className="md:hidden flex items-center gap-2 px-3 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors border border-gray-300 dark:border-gray-600 rounded-lg"
-                  >
-                    <Filter className="h-5 w-5" />
-                    {(filterStatus !== 'all' || filterPriority !== 'all') && (
-                      <span className="bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 text-xs px-2 py-1 rounded-full">
-                        Active
-                      </span>
-                    )}
-                    {isFiltersExpanded ? (
-                      <ChevronUp className="h-4 w-4" />
-                    ) : (
-                      <ChevronDown className="h-4 w-4" />
-                    )}
-                  </button>
+                  {(filterStatus !== 'all' || filterPriority !== 'all') && (
+                    <p className="mt-2 text-xs font-medium text-indigo-600 dark:text-indigo-300">
+                      Filters active
+                    </p>
+                  )}
                 </div>
-              </div>
 
-              {/* Collapsible filters (mobile) */}
-              <div className={`md:hidden ${isFiltersExpanded ? 'block' : 'hidden'} border-t border-gray-200 dark:border-gray-700`}>
-                <div className="p-4 space-y-4">
-                  {/* Status Filter */}
-                  <div className="relative">
-                    <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                    <select
-                      value={filterStatus}
-                      onChange={(e) => setFilterStatus(e.target.value as 'all' | 'active' | 'completed')}
-                      className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
-                    >
-                      <option value="all">All Status</option>
-                      <option value="active">Active</option>
-                      <option value="completed">Completed</option>
-                    </select>
-                  </div>
+                <div className="w-full md:w-auto">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 gap-3 md:min-w-[320px]">
+                    {/* Status Filter */}
+                    <div className="relative">
+                      <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                      <select
+                        value={filterStatus}
+                        onChange={(e) => setFilterStatus(e.target.value as 'all' | 'active' | 'completed')}
+                        className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
+                      >
+                        <option value="all">All Status</option>
+                        <option value="active">Active</option>
+                        <option value="completed">Completed</option>
+                      </select>
+                    </div>
 
-                  {/* Priority Filter */}
-                  <div>
-                    <select
-                      value={filterPriority}
-                      onChange={(e) => setFilterPriority(e.target.value as 'all' | 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT')}
-                      className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
-                    >
-                      <option value="all">All Priorities</option>
-                      <option value="URGENT">Urgent Priority</option>
-                      <option value="HIGH">High Priority</option>
-                      <option value="MEDIUM">Medium Priority</option>
-                      <option value="LOW">Low Priority</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-
-              {/* Always visible filters (desktop) */}
-              <div className="hidden md:block p-4 border-t border-gray-200 dark:border-gray-700">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {/* Status Filter */}
-                  <div className="relative">
-                    <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                    <select
-                      value={filterStatus}
-                      onChange={(e) => setFilterStatus(e.target.value as 'all' | 'active' | 'completed')}
-                      className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
-                    >
-                      <option value="all">All Status</option>
-                      <option value="active">Active</option>
-                      <option value="completed">Completed</option>
-                    </select>
-                  </div>
-
-                  {/* Priority Filter */}
-                  <div>
-                    <select
-                      value={filterPriority}
-                      onChange={(e) => setFilterPriority(e.target.value as 'all' | 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT')}
-                      className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
-                    >
-                      <option value="all">All Priorities</option>
-                      <option value="URGENT">Urgent Priority</option>
-                      <option value="HIGH">High Priority</option>
-                      <option value="MEDIUM">Medium Priority</option>
-                      <option value="LOW">Low Priority</option>
-                    </select>
+                    {/* Priority Filter */}
+                    <div>
+                      <select
+                        value={filterPriority}
+                        onChange={(e) => setFilterPriority(e.target.value as 'all' | 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT')}
+                        className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white transition-colors appearance-none"
+                      >
+                        <option value="all">All Priorities</option>
+                        <option value="URGENT">Urgent Priority</option>
+                        <option value="HIGH">High Priority</option>
+                        <option value="MEDIUM">Medium Priority</option>
+                        <option value="LOW">Low Priority</option>
+                      </select>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove the collapsible filter toggle and adopt a mobile-first layout for the search/filters card
- keep filters always accessible with an inline active indicator and responsive grid styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb80b39b48330a2374d733c0f17c8